### PR TITLE
Make txyam compatible with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+sudo: false
 language: python
 python:
   - "2.7"
+  - "3.5"
   - "pypy"
-install: pip install . --use-mirrors
+install: pip install .
 script: trial txyam

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,5 @@
 # txyam: Yet Another Memcached (YAM) client for Twisted
-[![Build Status](https://secure.travis-ci.org/bmuller/txyam.png?branch=master)](https://travis-ci.org/bmuller/txyam)
+[![Build Status](https://secure.travis-ci.org/Weasyl/txyam2.svg?branch=master)](https://travis-ci.org/Weasyl/txyam2)
 
 This project is specifically designed for asynchronous [Python Twisted](http://twistedmatrix.com) code to interact with multiple [memcached](http://memcached.org) servers.  A number of other libraries exist, but none of them supported all of the following:
 
@@ -50,4 +50,4 @@ calls just pull the results from memcache.  The function will be memoized based 
 name and arguments.  The function being memoized can return an object, which will be picked before saving.
 
 ## Errors / Bugs / Contact
-See [github](http://github.com/bmuller/txyam).
+See [github](http://github.com/Weasyl/txyam2).

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'twisted>=16.4',
-        'consistent_hash',
+        'consistent_hash_git==0.3',
     ],
     extras_require={
         'sync': [

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     url="https://github.com/Weasyl/txyam2",
     packages=find_packages(),
     install_requires=[
-        'twisted>=12.0',
+        'twisted>=16.4',
         'consistent_hash',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author="Brian Muller",
     author_email="bamuller@gmail.com",
     license="MIT",
-    url="http://github.com/bmuller/txyam",
+    url="https://github.com/Weasyl/txyam2",
     packages=find_packages(),
     install_requires=[
         'twisted>=12.0',

--- a/txyam/client.py
+++ b/txyam/client.py
@@ -9,6 +9,20 @@ from txyam.utils import deferredDict
 from txyam.factory import MemCacheClientFactory
 
 
+if hasattr(dict, "iteritems"):
+    def iteritems(d):
+        return d.iteritems()
+
+    def itervalues(d):
+        return d.itervalues()
+else:
+    def iteritems(d):
+        return d.items()
+
+    def itervalues(d):
+        return d.values()
+
+
 def _wrap(cmd):
     """
     Used to wrap all of the memcache methods (get,set,getMultiple,etc).
@@ -83,7 +97,7 @@ class YamClient(object):
 
     @property
     def _allConnections(self):
-        return self._protocols.itervalues()
+        return itervalues(self._protocols)
 
     def disconnect(self):
         self.disconnecting = True
@@ -99,13 +113,13 @@ class YamClient(object):
 
     def stats(self, arg=None):
         ds = {}
-        for host, proto in self._protocols.iteritems():
+        for host, proto in iteritems(self._protocols):
             ds[host] = proto.stats(arg)
         return deferredDict(ds)
 
     def version(self):
         ds = {}
-        for host, proto in self._protocols.iteritems():
+        for host, proto in iteritems(self._protocols):
             ds[host] = proto.version()
         return deferredDict(ds)
 
@@ -117,7 +131,7 @@ class YamClient(object):
         for key in keys:
             clients[self.getClient(key)].append(key)
         dl = defer.DeferredList(
-            [c.getMultiple(ks, withIdentifier) for c, ks in clients.iteritems()
+            [c.getMultiple(ks, withIdentifier) for c, ks in iteritems(clients)
              if c is not None],
             consumeErrors=True)
         dl.addCallback(self._consolidateMultiple)
@@ -125,7 +139,7 @@ class YamClient(object):
 
     def setMultiple(self, items, flags=0, expireTime=0):
         ds = {}
-        for key, value in items.iteritems():
+        for key, value in iteritems(items):
             ds[key] = self.set(key, value, flags, expireTime)
         return deferredDict(ds)
 


### PR DESCRIPTION
Depends on twisted.protocols.memcache’s compatibility.
